### PR TITLE
Clearing the input field

### DIFF
--- a/src/view/TaskView.java
+++ b/src/view/TaskView.java
@@ -95,6 +95,7 @@ public class TaskView extends JPanel implements ActionListener, PropertyChangeLi
                             JLabel newTaskText = new JLabel(currentState.getTask());
                             newTask.add(newTaskText);
                             newTask.add(completeTask);
+                            createInputField.setText("");
 
                             taskPanel.add(newTask);
                             taskPanel.revalidate();


### PR DESCRIPTION
Changed the code slightly so that once the task is added the create task input field is cleared so that another task can be added without the user having to delete the text in the input field. 