### PR TITLE
Display Task Use Case GetAllTasks Method

### DIFF
--- a/src/data_access/FileTaskDataAccessObject.java
+++ b/src/data_access/FileTaskDataAccessObject.java
@@ -11,9 +11,7 @@ import use_case.display_task.DisplayTaskDataAccessInterface;
 
 import java.io.*;
 import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 
 import static java.lang.Boolean.parseBoolean;
 
@@ -66,8 +64,16 @@ public class FileTaskDataAccessObject implements CreateTaskDataAccessInterface, 
     }
 
     @Override
-    public Map<String, TaskI> getAllTasks() {
-        return tasks;
+    public Map<String, Set<Object>> getAllTasks() {
+        Map<String, Set<Object>> retTask = new HashMap<>();
+
+        for (String task: tasks.keySet()) {
+            Set<Object> taskInfo = new HashSet<>();
+            taskInfo.add(tasks.get(task).getComplete());
+            retTask.put(task, taskInfo);
+        }
+
+        return retTask;
     }
 
     public void save() {

--- a/src/use_case/display_task/DisplayTaskDataAccessInterface.java
+++ b/src/use_case/display_task/DisplayTaskDataAccessInterface.java
@@ -3,9 +3,10 @@ package use_case.display_task;
 import entity.TaskI;
 
 import java.util.Map;
+import java.util.Set;
 
 public interface DisplayTaskDataAccessInterface {
 
-    Map<String, TaskI> getAllTasks();
+    Map<String, Set<Object>> getAllTasks();
 
 }


### PR DESCRIPTION
I changed the display task data access interface and the file task data access object to specifically change the getAllTasks method. I wanted to allow this method the capability of containing all information regarding a task so that other parts of the program could use the task information without violating the CA engine.